### PR TITLE
Add depth effect to bricks with vertical gradient

### DIFF
--- a/game.js
+++ b/game.js
@@ -128,6 +128,14 @@ function drawBricks() {
         ctx.fillStyle = b.texture;
         ctx.fillRect(brickX, brickY, brickWidth, brickHeight);
 
+        // Dégradé vertical pour le relief
+        const relief = ctx.createLinearGradient(brickX, brickY, brickX, brickY + brickHeight);
+        relief.addColorStop(0, "rgba(255,255,255,0.3)");
+        relief.addColorStop(0.5, "rgba(255,255,255,0)");
+        relief.addColorStop(1, "rgba(0,0,0,0.3)");
+        ctx.fillStyle = relief;
+        ctx.fillRect(brickX, brickY, brickWidth, brickHeight);
+
         const hueMatch = /hsl\((\d+),/.exec(b.color);
         if (hueMatch) {
           const h = hueMatch[1];

--- a/game.js
+++ b/game.js
@@ -128,23 +128,30 @@ function drawBricks() {
         ctx.fillStyle = b.texture;
         ctx.fillRect(brickX, brickY, brickWidth, brickHeight);
 
-        // Dégradé vertical pour le relief
-        const relief = ctx.createLinearGradient(brickX, brickY, brickX, brickY + brickHeight);
-        relief.addColorStop(0, "rgba(255,255,255,0.3)");
-        relief.addColorStop(0.5, "rgba(255,255,255,0)");
-        relief.addColorStop(1, "rgba(0,0,0,0.3)");
-        ctx.fillStyle = relief;
+        // Dégradés pour accentuer le relief
+        const reliefV = ctx.createLinearGradient(brickX, brickY, brickX, brickY + brickHeight);
+        reliefV.addColorStop(0, "rgba(255,255,255,0.6)");
+        reliefV.addColorStop(0.5, "rgba(255,255,255,0)");
+        reliefV.addColorStop(1, "rgba(0,0,0,0.6)");
+        ctx.fillStyle = reliefV;
+        ctx.fillRect(brickX, brickY, brickWidth, brickHeight);
+
+        const reliefH = ctx.createLinearGradient(brickX, brickY, brickX + brickWidth, brickY);
+        reliefH.addColorStop(0, "rgba(255,255,255,0.2)");
+        reliefH.addColorStop(0.5, "rgba(255,255,255,0)");
+        reliefH.addColorStop(1, "rgba(0,0,0,0.2)");
+        ctx.fillStyle = reliefH;
         ctx.fillRect(brickX, brickY, brickWidth, brickHeight);
 
         const hueMatch = /hsl\((\d+),/.exec(b.color);
         if (hueMatch) {
           const h = hueMatch[1];
-          ctx.fillStyle = `hsl(${h}, 100%, 70%)`;
-          ctx.fillRect(brickX, brickY, brickWidth, 4);
-          ctx.fillRect(brickX, brickY, 4, brickHeight);
-          ctx.fillStyle = `hsl(${h}, 100%, 30%)`;
-          ctx.fillRect(brickX, brickY + brickHeight - 4, brickWidth, 4);
-          ctx.fillRect(brickX + brickWidth - 4, brickY, 4, brickHeight);
+          ctx.fillStyle = `hsl(${h}, 100%, 85%)`;
+          ctx.fillRect(brickX, brickY, brickWidth, 3);
+          ctx.fillRect(brickX, brickY, 3, brickHeight);
+          ctx.fillStyle = `hsl(${h}, 100%, 15%)`;
+          ctx.fillRect(brickX, brickY + brickHeight - 3, brickWidth, 3);
+          ctx.fillRect(brickX + brickWidth - 3, brickY, 3, brickHeight);
         }
         ctx.restore();
       }


### PR DESCRIPTION
## Summary
- add vertical gradient overlay to bricks to create 2D depth effect

## Testing
- `node --check game.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68962c2c0e0883299da3eaaae069a679